### PR TITLE
refactor: 使用iconify官方推出的tailwind插件

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - 使用 [Vite](https://vitejs.dev/) 进行静态资源构建。
 - 使用 [Tailwind CSS](https://tailwindcss.com/) 进行样式开发。
 - 使用 [@tailwindcss/typography](https://tailwindcss.com/docs/typography-plugin) 作为内容样式。
-- 使用 [Iconify](https://iconify.design/) + [tailwindcss-plugin-icons](https://github.com/JensDll/tailwindcss-plugin-icons) 作为图标方案。
+- 使用 [Iconify](https://iconify.design/) + [@iconify/tailwind](https://iconify.design/docs/usage/css/tailwind/#installation) 作为图标方案。
 - 集成了 [Alpine.js](https://alpinejs.dev/)。
 - 集成了 ESLint + Prettier。
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@iconify-json/tabler": "^1.1.96",
+    "@iconify/tailwind": "^0.1.4",
     "@tailwindcss/typography": "^0.5.10",
     "@types/alpinejs": "^3.13.5",
     "@types/node": "^18.18.9",
@@ -49,7 +50,6 @@
     "prettier": "^2.8.8",
     "prettier-plugin-tailwindcss": "^0.1.13",
     "tailwindcss": "^3.3.5",
-    "tailwindcss-plugin-icons": "^2.2.0",
     "typescript": "^4.9.5",
     "vite": "^4.5.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   alpinejs:
     specifier: ^3.13.2
@@ -12,7 +8,10 @@ dependencies:
 devDependencies:
   '@iconify-json/tabler':
     specifier: ^1.1.96
-    version: 1.1.96
+    version: 1.1.105
+  '@iconify/tailwind':
+    specifier: ^0.1.4
+    version: 0.1.4
   '@tailwindcss/typography':
     specifier: ^0.5.10
     version: 0.5.10(tailwindcss@3.3.5)
@@ -52,9 +51,6 @@ devDependencies:
   tailwindcss:
     specifier: ^3.3.5
     version: 3.3.5
-  tailwindcss-plugin-icons:
-    specifier: ^2.2.0
-    version: 2.2.0(tailwindcss@3.3.5)
   typescript:
     specifier: ^4.9.5
     version: 4.9.5
@@ -329,8 +325,14 @@ packages:
     resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
     dev: true
 
-  /@iconify-json/tabler@1.1.96:
-    resolution: {integrity: sha512-BozRq6622JUEOBlZhF/l6UxqwHoWFiaLP6UCH9/mOvuek/tZureuQ2DSEaz5SdpKJamtBQjtJCH6zzsim6YKUQ==}
+  /@iconify-json/tabler@1.1.105:
+    resolution: {integrity: sha512-USJbNfa0fAHBLilxTKn70wkvFnopmfcomfpqD0ul/69uyZnonztHhyrbM8MI9Ua4eYXaPymoB7tuZ+Ionx6xfg==}
+    dependencies:
+      '@iconify/types': 2.0.0
+    dev: true
+
+  /@iconify/tailwind@0.1.4:
+    resolution: {integrity: sha512-U7RzcU2fkwOfMDsGQ3mtpLIaApSnqb+vgcJJknPPbg8/NF5s7tI1o5otEMfcpnLGk4PbYB8bxmKTz7IJVUlU2Q==}
     dependencies:
       '@iconify/types': 2.0.0
     dev: true
@@ -1641,14 +1643,6 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /tailwindcss-plugin-icons@2.2.0(tailwindcss@3.3.5):
-    resolution: {integrity: sha512-gtAYh5eAIazE0AmqmD+I//yrpQGHqgS6zkxE2ftlMHZuQURiR4HGpjtOtyJeNqKmVmCPgzqVF+R+hB9QZWzVjg==}
-    peerDependencies:
-      tailwindcss: 3.x
-    dependencies:
-      tailwindcss: 3.3.5
-    dev: true
-
   /tailwindcss@3.3.5:
     resolution: {integrity: sha512-5SEZU4J7pxZgSkv7FP1zY8i2TIAOooNZ1e/OGtxIEv6GltpoiXUqWvLy89+a10qYTB1N5Ifkuw9lqQkN9sscvA==}
     engines: {node: '>=14.0.0'}
@@ -1826,3 +1820,7 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-const { Icons } = require("tailwindcss-plugin-icons");
+const { addDynamicIconSelectors } = require('@iconify/tailwind');
 module.exports = {
   content: ["./templates/**/*.html", "./src/main.ts"],
   theme: {
@@ -7,11 +7,7 @@ module.exports = {
   },
   plugins: [
     require("@tailwindcss/typography"),
-    Icons(() => ({
-      tabler: {
-        includeAll: true,
-      },
-    })),
+    addDynamicIconSelectors(),
   ],
   safelist: [
     "prose-sm",

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,7 @@
     <div class="mx-auto flex h-screen w-96 flex-col items-center justify-center">
       <ul class="w-full list-inside list-disc">
         <li th:each="post : ${posts.items}">
+          <span class="icon-[tabler--box]"></span>
           <a
             th:text="${post.spec.title}"
             th:href="${post.status.permalink}"


### PR DESCRIPTION
Iconify 官方提供了针对 Tailwind CSS 的图标代码复制功能，因此请求将原本的 icon 插件替换为 Iconify 官方支持的 tailwind 插件。
![image](https://github.com/halo-dev/theme-modern-starter/assets/27671436/1413b13a-753c-4c3b-9536-1cf38fe7c364)
